### PR TITLE
Apps: move access token logic to API

### DIFF
--- a/apps/api/src/routes/contract.ts
+++ b/apps/api/src/routes/contract.ts
@@ -33,13 +33,13 @@ export const contract = c.router(
       responses: {
         201: z.string()
       },
-      body: c.type<AccessToken>(),
+      body: z.undefined(),
       summary: 'Logout of Spotify'
     },
     getFavs: {
       method: 'POST',
       path: `/favs`,
-      body: c.type<{ accessToken: AccessToken; timeRange: TimeRange }>(),
+      body: c.type<{ timeRange: TimeRange }>(),
       responses: {
         200: c.type<Awaited<ReturnType<typeof getFavs>>>()
       },
@@ -49,7 +49,6 @@ export const contract = c.router(
       method: 'POST',
       path: '/create-playlist',
       body: c.type<{
-        accessToken: AccessToken
         genres: string[]
         playlistName: string
         requestedPopularity: number

--- a/apps/web/src/views/HomeView.vue
+++ b/apps/web/src/views/HomeView.vue
@@ -9,7 +9,6 @@ import { Label } from '@/components/ui/label'
 import { Spinner } from '@/components/ui/spinner'
 
 const {
-  accessToken,
   login,
   getFavs,
   createPlaylist,
@@ -17,7 +16,8 @@ const {
   timeRange,
   favouriteGenres,
   selectedGenres,
-  isLoadingFavs
+  isLoadingFavs,
+  isLoggedIn
 } = useSpotify()
 
 const toggleGenre = (genre: string, isSelected: boolean) => {
@@ -43,7 +43,7 @@ const playlistName = ref('')
   <main>
     <h2>Genre Blender</h2>
 
-    <Button v-if="!accessToken">
+    <Button v-if="!isLoggedIn">
       <a @click="login"> LOG IN TO SPOTIFY </a>
     </Button>
 

--- a/apps/web/src/views/LoginView.vue
+++ b/apps/web/src/views/LoginView.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 import useSpotify from '@/composables/useSpotify'
 import { Spinner } from '@/components/ui/spinner'
 
-const { accessToken, isLoggedIn, login } = useSpotify()
+const { isLoggedIn, login } = useSpotify()
 
 onBeforeMount(async () => {
   await login()
@@ -13,8 +13,6 @@ onBeforeMount(async () => {
 
   router.go(-1)
 })
-
-console.log('after login', accessToken.value)
 
 const router = useRouter()
 </script>


### PR DESCRIPTION
- Use `spotify` as a global variable in the API
- Remove access token handling, logs in web
- Don't send access token as parameter from web to API

There are still some things to improve such as:
- Better error handling
- Atomising the logic to get the access token in the backend
But for now it will suffice.